### PR TITLE
Move dupicate lambda content to named function

### DIFF
--- a/JoyShockMapper/include/JoyShockMapper.h
+++ b/JoyShockMapper/include/JoyShockMapper.h
@@ -292,7 +292,7 @@ private:
 	map<BtnEvent, OnEventAction> eventMapping;
 	float tapDurationMs = MAGIC_TAP_DURATION;
 	void InsertEventMapping(BtnEvent evt, OnEventAction action);
-	static void RunAllActions(DigitalButton *btn, int numEventActions, ...);
+	static void RunBothActions(DigitalButton *btn, OnEventAction action1, OnEventAction action2);
 
 public:
 	Mapping() = default;


### PR DESCRIPTION
Lambdas are good and powerful, but they can obscure the code very quickly. With these changes, the executed code is exactly the same, but we use a named function instead of a nameless lambda, and intentionality is expressed in the parameter bindings.